### PR TITLE
[Helm] Generate KCL schema from chart's JSON Schema

### DIFF
--- a/cmd/add_helm.go
+++ b/cmd/add_helm.go
@@ -10,6 +10,7 @@ import (
 var (
 	version   string
 	directory string
+	useSchema bool
 )
 
 var helmCmd = &cobra.Command{
@@ -28,7 +29,7 @@ You can then import the podinfo chart from vendored/helm/podinfo.`,
 			Repository: argsGet(args, 0),
 			Name:       argsGet(args, 1),
 			Version:    version,
-		}, directory)
+		}, directory, useSchema)
 		return err
 	},
 }
@@ -39,4 +40,5 @@ func init() {
 	helmCmd.Flags().StringVarP(&version, "version", "v", "", "version of the helm chart")
 	helmCmd.MarkFlagRequired("version")
 	helmCmd.Flags().StringVar(&directory, "dir", filepath.Join("vendored", "helm"), "directory to add helm chart configuration")
+	helmCmd.Flags().BoolVar(&useSchema, "use-schema", false, "if true, attempts to use the values.schema.json included with the helm chart")
 }

--- a/pkg/helm/import.go
+++ b/pkg/helm/import.go
@@ -33,7 +33,7 @@ func Import(chartRef *ChartRef, directory string, useSchema bool) error {
 	} else {
 		if useSchema {
 			logger := logging.GetInstance()
-			logger.Println("WARN: Schema not included with helm chart. Parsing schema from default values instead.")
+			logger.Println("WARN: Schema not included with helm chart. Inferring schema from default values instead.")
 		}
 
 		valuesNode, err := getValues(chart)

--- a/pkg/helm/import.go
+++ b/pkg/helm/import.go
@@ -4,24 +4,47 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"knit/pkg/logging"
 	"knit/pkg/util"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"helm.sh/helm/v3/pkg/cli"
 	"kcl-lang.io/kcl-go"
 	"kcl-lang.io/kcl-go/pkg/tools/gen"
 )
 
-func Import(chartRef *ChartRef, directory string) error {
-	valuesNode, err := getValues(chartRef)
+func Import(chartRef *ChartRef, directory string, useSchema bool) error {
+	settings := cli.New()
+
+	chart, err := getChart(chartRef, settings)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not get helm chart: %w", err)
 	}
 
-	schema, err := ValuesNodeToJsonSchema(valuesNode)
-	if err != nil {
-		return err
+	var schema *JsonSchema
+
+	if useSchema && len(chart.Schema) > 0 {
+		err = json.Unmarshal(chart.Schema, &schema)
+		if err != nil {
+			return fmt.Errorf("could not parse JSON schema provided with the helm chart. Try adding without using the provided schema.\n%w", err)
+		}
+	} else {
+		if useSchema {
+			logger := logging.GetInstance()
+			logger.Println("WARN: Schema not included with helm chart. Parsing schema from default values instead.")
+		}
+
+		valuesNode, err := getValues(chart)
+		if err != nil {
+			return err
+		}
+
+		schema, err = ValuesNodeToJsonSchema(valuesNode)
+		if err != nil {
+			return err
+		}
 	}
 
 	schemaJSON, err := json.Marshal(schema)

--- a/pkg/helm/schema.go
+++ b/pkg/helm/schema.go
@@ -5,7 +5,7 @@ import (
 )
 
 type JsonSchema struct {
-	Type        string                 `json:"type,omitempty"`
+	Type        interface{}            `json:"type,omitempty"` // Can be string or []string
 	Default     interface{}            `json:"default,omitempty"`
 	Description string                 `json:"description,omitempty"`
 	Properties  map[string]*JsonSchema `json:"properties,omitempty"`

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -6,7 +6,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/cli"
 )
 
 type JSONType int
@@ -29,14 +28,7 @@ type ValuesNode struct {
 	SubNodes []*ValuesNode
 }
 
-func getValues(chartRef *ChartRef) (*ValuesNode, error) {
-	settings := cli.New()
-
-	chart, err := getChart(chartRef, settings)
-	if err != nil {
-		return nil, fmt.Errorf("could not get helm chart: %w", err)
-	}
-
+func getValues(chart *chart.Chart) (*ValuesNode, error) {
 	valuesFile, err := getValuesFile(chart)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add option to use a provided values schema from the chart to generate KCL schema.

Provide the option `--use-schema` on the command `knit add helm` to attempt to use an included `values.schema.json` file in the helm chart.

Ref: https://helm.sh/docs/topics/charts/#schema-files