### PR TITLE
fix: correctly translate yaml scalar type timestamp to json string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.vscode/*

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -103,6 +103,8 @@ func parseYAML(node *yaml.Node, name string) (*ValuesNode, error) {
 			vNode.Type = TypeNumber
 		case "!!bool":
 			vNode.Type = TypeBool
+		case "!!timestamp":
+			vNode.Type = TypeString
 		case "!!null":
 			vNode.Type = TypeNull
 		default:
@@ -126,10 +128,10 @@ func parseYAML(node *yaml.Node, name string) (*ValuesNode, error) {
 				return nil, fmt.Errorf("non-scalar key in mapping")
 			}
 			child, err := parseYAML(valueNode, keyNode.Value)
-			child.Comments = collectComments(keyNode, valueNode)
 			if err != nil {
 				return nil, err
 			}
+			child.Comments = collectComments(keyNode, valueNode)
 			vNode.SubNodes = append(vNode.SubNodes, child)
 		}
 	case yaml.AliasNode:


### PR DESCRIPTION
### Context:
YAML has a scalar type [timestamp ](https://yaml.org/type/timestamp.html) which is [not part](https://www.json.org/json-en.html) of JSON and should be handled as a string. As of now this is not handled in the code. More over if there is an error which is return from [parseYAML ](https://github.com/tvandinther/knit/blob/main/pkg/helm/values.go#L128) collectComments will panic because the error handling is done only after collectComments is called.

### How to reproduce:
```
knit add helm https://grafana.github.io/helm-charts loki --version 6.34.0
```

### Expected result:
Correctly adding helm chart

### Actual result:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x349d4cd]

goroutine 1 [running]:
knit/pkg/helm.parseYAML(0xc001c29ea0, {0x0, 0x0})
        /tmp/knit/pkg/helm/values.go:129 +0x54d
knit/pkg/helm.parseYAML(0xc001c29e00, {0xc001c12690, 0x7})
        /tmp/knit/pkg/helm/values.go:114 +0x385
knit/pkg/helm.parseYAML(0xc001c29cc0, {0xc001c12680, 0x10})
        /tmp/knit/pkg/helm/values.go:128 +0x4fa
knit/pkg/helm.parseYAML(0xc001bab180, {0xc001b75e78, 0x4})
        /tmp/knit/pkg/helm/values.go:128 +0x4fa
knit/pkg/helm.parseYAML(0xc001423900, {0x444498c, 0x4})
        /tmp/knit/pkg/helm/values.go:128 +0x4fa
knit/pkg/helm.getValues(0xc001593c70?)
        /tmp/knit/pkg/helm/values.go:47 +0x13b
knit/pkg/helm.Import(0xc0013e3c70, {0xc0007951e0, 0xd}, 0x0)
        /tmp/knit/pkg/helm/import.go:39 +0x22a
knit/cmd.init.func1(0x6521e20?, {0xc00097e080?, 0x2?, 0x4?})
        /tmp/knit/cmd/add_helm.go:28 +0x9c
github.com/spf13/cobra.(*Command).execute(0x6521e20, {0xc00097e040, 0x4, 0x4})
        /home/aaa/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xad4
github.com/spf13/cobra.(*Command).ExecuteC(0x65226c0)
        /home/aaa/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x44f
github.com/spf13/cobra.(*Command).Execute(...)
        /home/aaa/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
knit/cmd.Execute()
        /tmp/knit/cmd/root.go:36 +0x1a
main.main()
        /tmp/knit/main.go:8 +0xf
